### PR TITLE
fixing the stripe issue, that send the amount of the plan without zeros

### DIFF
--- a/actions/subscriptions/plans/sync.php
+++ b/actions/subscriptions/plans/sync.php
@@ -53,7 +53,6 @@ if ($plans->data) {
 
 			$site_plan->setPlanId($plan->id);
 			$site_plan->setCycle(null, $plan->interval, $plan->interval_count);
-			system_message(elgg_echo('subscriptions:plans:import:success', array($plan->id)))
 			$site_plan->setAmount($plan->amount/100.00);
 			$site_plan->setCurrency($plan->currency);
 			$site_plan->setTrialPeriodDays($plan->trial_period_days);

--- a/actions/subscriptions/plans/sync.php
+++ b/actions/subscriptions/plans/sync.php
@@ -53,7 +53,8 @@ if ($plans->data) {
 
 			$site_plan->setPlanId($plan->id);
 			$site_plan->setCycle(null, $plan->interval, $plan->interval_count);
-			$site_plan->setAmount($plan->amount);
+			system_message(elgg_echo('subscriptions:plans:import:success', array($plan->id)))
+			$site_plan->setAmount($plan->amount/100.00);
 			$site_plan->setCurrency($plan->currency);
 			$site_plan->setTrialPeriodDays($plan->trial_period_days);
 


### PR DESCRIPTION
This is fix for an errors that comes from the stripe service. When they send the amount for a plan that is 20 $, they send 2000, like you can see in this json:

{
  "interval": "month",
  "name": "Gold Special",
  "created": 1420728626,
  "amount": 2000,
  "currency": "eur",
  "id": "gold",
  "object": "plan",
  "livemode": false,
  "interval_count": 1,
  "trial_period_days": null,
  "metadata": {
  },
  "statement_descriptor": null
}
In the stripe dashboard you see the value, as EUR 20.00/monthly, but in elgg sync you see the value that comes from this json, So i just divided by 100, to get the right value.  
